### PR TITLE
Adding a null check when loading an icon from the sprite.

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,14 +445,16 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
           style = iconImageCache[icon];
           if (!style && spriteData && spriteImageUrl) {
             var spriteImageData = spriteData[icon];
-            style = iconImageCache[icon] = new Style({
-              image: new Icon({
-                src: spriteImageUrl,
-                size: [spriteImageData.width, spriteImageData.height],
-                offset: [spriteImageData.x, spriteImageData.y],
-                scale: paint['icon-size'](zoom, properties) / spriteImageData.pixelRatio
-              })
-            });
+            if (spriteImageData) {
+              style = iconImageCache[icon] = new Style({
+                image: new Icon({
+                  src: spriteImageUrl,
+                  size: [spriteImageData.width, spriteImageData.height],
+                  offset: [spriteImageData.x, spriteImageData.y],
+                  scale: paint['icon-size'](zoom, properties) / spriteImageData.pixelRatio
+                })
+              });
+            }
           }
           if (style) {
             var iconImg = style.getImage();


### PR DESCRIPTION
- For styles where you get the icon name from a data property, there is the possibility that not all icons exist in the sprite.
- Previously this would crash the map, this fix will just ignore the icon.