### PR TITLE
Performance optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,6 +417,18 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
   var lastProperties = {};
   var lastUsedPropertiesCount = 0;
 
+  var layersBySourceLayer = {};
+  var layersWithoutSourceLayer = [];
+
+  layers.forEach(function (layer, index) {
+    if (layer['source-layer']) {
+      layersBySourceLayer[layer['source-layer']] = layersBySourceLayer[layer['source-layer']] || [];
+      layersBySourceLayer[layer['source-layer']].push([layer, index]);
+    } else {
+      layersWithoutSourceLayer.push([layer, index]);
+    }
+  });
+
   return function(feature, resolution) {
     var zoom = resolutions.indexOf(resolution);
     if (zoom == -1) {
@@ -446,10 +458,18 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
     lastZoom = zoom;
 
     var stylesLength = -1;
-    for (var i = 0, ii = layers.length; i < ii; ++i) {
-      var layer = layers[i];
-      if ((layer['source-layer'] && layer['source-layer'] != properties.layer) ||
-          ('minzoom' in layer && zoom < layer.minzoom) ||
+    var sourceLayersLength = 0;
+    var potentialLayers = [];
+    if (properties.layer && layersBySourceLayer[properties.layer]) {
+      potentialLayers = layersBySourceLayer[properties.layer];
+      sourceLayersLength = potentialLayers.length;
+    }
+
+    for (var i = 0, ii = sourceLayersLength + layersWithoutSourceLayer.length; i < ii; ++i) {
+      var layerAndIndex = i < sourceLayersLength ? potentialLayers[i] : layersWithoutSourceLayer[i];
+      var layer = layerAndIndex[0]
+      var index = layerAndIndex[1]
+      if (('minzoom' in layer && zoom < layer.minzoom) ||
           ('maxzoom' in layer && zoom >= layer.maxzoom)) {
         continue;
       }
@@ -471,7 +491,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
               }
               fill = style.getFill();
               fill.setColor(color);
-              style.setZIndex(i);
+              style.setZIndex(index);
             }
             if ('fill-outline-color' in paint) {
               strokeColor = colorWithOpacity(paint['fill-outline-color'](zoom, properties), opacity);
@@ -491,7 +511,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
               stroke.setColor(strokeColor);
               stroke.setWidth(1);
               stroke.setLineDash(null);
-              style.setZIndex(i);
+              style.setZIndex(index);
             }
           }
         }
@@ -519,7 +539,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
                 paint['line-dasharray'](zoom, properties).map(function(x) {
                   return x * width;
                 }) : null);
-            style.setZIndex(i);
+            style.setZIndex(index);
           }
         }
 
@@ -546,7 +566,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
             var iconImg = style.getImage();
             iconImg.setRotation(deg2rad(paint['icon-rotate'](zoom, properties)));
             iconImg.setOpacity(paint['icon-opacity'](zoom, properties));
-            style.setZIndex(i);
+            style.setZIndex(index);
             styles[stylesLength] = style;
           }
         }
@@ -570,7 +590,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
               })
             });
           }
-          style.setZIndex(i);
+          style.setZIndex(index);
           styles[stylesLength] = style;
         }
 
@@ -621,7 +641,7 @@ export default function(glStyle, source, resolutions, spriteData, spriteImageUrl
           } else {
             text.setStroke(undefined);
           }
-          style.setZIndex(i);
+          style.setZIndex(index);
         }
       }
     }


### PR DESCRIPTION
I've been working on some performance optimizations. This pull request contains two of them:
1. reuse styles from the previous invocation if the properties do not differ in the properties that can affect feature styling (the properties that affect styling are calculated dynamically from the style)
2. use the `layer` of a feature to only test for the styles that use that layer as `source-layer`

The effect of these two can be compared with the [before](https://joux3.github.io/mapbox-to-ol-style/perftest/before.html) and [after](https://joux3.github.io/mapbox-to-ol-style/perftest/after.html) maps. Here's a sample of the JS profiles between these maps: 
![developer_tools_-_https___joux3_github_io_mapbox-to-ol-style_perftest_before_html_and_developer_tools_-_https___joux3_github_io_mapbox-to-ol-style_perftest_after_html](https://cloud.githubusercontent.com/assets/9249/24589518/65d556ca-17e4-11e7-96d3-5feba88ab710.png)

Are these changes something that could be upstreamed? In some cases at least the style reusing can actually worsen the runtime (namely styles that never match subsequently, but for vector maps with lots of e.g. road features this does not seem to be the case) which might warrant adding it behind a flag. The set of properties that can affect styling also does not handle [property functions](https://www.mapbox.com/mapbox-gl-js/style-spec/#types-function-zoom-property).

For my use case these optimizations have already made `mapbox-to-ol-style` "fast enough" for me, but there's still at least some more things to optimize:
1. filter evaluation based on generated JS functions (similar to what `mapbox-gl-js` does in its [`feature-filter`)](https://github.com/mapbox/mapbox-gl-js/tree/master/src/style-spec/feature_filter)
2. figure out why the JIT in Chrome V8 stops using an optimized version of the style function after a while. this would probably require splitting the styling to separate functions