### PR TITLE
Support data driven styling (color interpolation)

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,22 +31,22 @@ var functions = {
     'circle-radius',
     'circle-opacity',
     'circle-stroke-width',
-    'circle-color'
+    'circle-color',
+    'circle-stroke-color',
+    'text-halo-color',
+    'text-color',
+    'line-color',
+    'fill-outline-color',
+    'fill-color'
   ],
   'piecewise-constant': [
-    'fill-color',
-    'fill-outline-color',
     'icon-image',
     'line-cap',
-    'line-color',
     'line-join',
     'line-dasharray',
     'text-anchor',
-    'text-color',
     'text-field',
-    'text-font',
-    'text-halo-color',
-    'circle-stroke-color'
+    'text-font'
   ]
 };
 
@@ -110,6 +110,7 @@ function convertToFunctions(properties, type) {
   for (var i = 0, ii = functions[type].length; i < ii; ++i) {
     var property = functions[type][i];
     if (property in properties) {
+      propertySpec.type = property.indexOf('color') !== -1 ? 'color' : undefined;
       properties[property] = glfun(properties[property], propertySpec);
     }
   }
@@ -201,13 +202,25 @@ function colorWithOpacity(color, opacity) {
   if (color && opacity !== undefined) {
     var colorData = colorCache[color];
     if (!colorData) {
-      colorElement.style.color = color;
-      document.body.appendChild(colorElement);
-      var colorString = getComputedStyle(colorElement).getPropertyValue('color');
-      document.body.removeChild(colorElement);
-      var colorArray = colorString.match(colorRegEx)[1].split(',').map(Number);
-      if (colorArray.length == 3) {
-        colorArray.push(1);
+      var colorArray;
+      if (Array.isArray(color)) {
+        colorArray = [];
+        for (var i = 0, ii = color.length; i < ii; i++) {
+          if (i < 3) {
+            colorArray.push(255 * color[i]);
+          } else {
+            colorArray.push(color[i]);
+          }
+        }
+      } else {
+        colorElement.style.color = color;
+        document.body.appendChild(colorElement);
+        var colorString = getComputedStyle(colorElement).getPropertyValue('color');
+        document.body.removeChild(colorElement);
+        colorArray = colorString.match(colorRegEx)[1].split(',').map(Number);
+        if (colorArray.length == 3) {
+          colorArray.push(1);
+        }
       }
       colorCache[color] = colorData = {
         color: colorArray,


### PR DESCRIPTION
I noticed that interpolation functions did not work okay, the colors were off. So it turns out that type: 'color' is needed for the function definition.

In addition, the output of the function will be:

```
// GL expects all components to be in the range [0, 1] and to be
// multipled by the alpha value.
return [
rgba[0] / 255 * rgba[3],
rgba[1] / 255 * rgba[3],
rgba[2] / 255 * rgba[3],
rgba[3]
];
```

so we need to translate those so that openlayers understands them.

Now the colors of the circles are correct:

![selection_391](https://user-images.githubusercontent.com/319678/30339685-23e89308-97f0-11e7-9afa-2e8693bde072.png)
