### PR TITLE
Match tokens in multi-line templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ function deg2rad(degrees) {
   return degrees * Math.PI / 180;
 }
 
-var templateRegEx = /^(.*)\{(.*)\}(.*)$/;
+var templateRegEx = /^([^]*)\{(.*)\}([^]*)$/;
 
 function fromTemplate(text, properties) {
   var parts;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     {
       "name": "Antti Risteli",
       "email": "antti@kiinnost.us"
+    },
+    {
+      "name": "Petr Sloup",
+      "email": "petr.sloup@klokantech.com"
     }
   ],
   "license": "BSD-2-Clause",


### PR DESCRIPTION
In some cases, the `text-field` can be multiline (e.g. some OpenMapTiles styles use this for displaying latin name with a non-latin alternative on the second line).

This PR slightly modifies the token matching regular expression to work even for multi-line labels.